### PR TITLE
renovate: extend the shared preset from SierranaTech/actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "github>SierranaTech/actions//renovate/common"
   ]
 }


### PR DESCRIPTION
Onboards this repo to the org's shared Renovate preset introduced in [SierranaTech/actions#29](https://github.com/SierranaTech/actions/pull/29). Minor+patch bumps per manager get batched into one PR; major bumps stay individual.